### PR TITLE
Fix define_target_function to not remove target function result names

### DIFF
--- a/R/define_target_function.R
+++ b/R/define_target_function.R
@@ -107,7 +107,7 @@ define_target_function <- function(targets, priors, FUN = NULL, use_seed = FALSE
           ans <- do.call(y[[idx]], as.list(c(x[reg_inp], special)))
         } else if (length(reg_inp) == 1) {
           # If target function expects a single vector
-          ans <- as.numeric(do.call(y[[idx]], as.list(c(list(x), special))))
+          ans <- do.call(y[[idx]], as.list(c(list(x), special)))
         } else {
           # If target is fixed
           ans <- y[[idx]]()
@@ -149,7 +149,7 @@ define_target_function <- function(targets, priors, FUN = NULL, use_seed = FALSE
         ans <- do.call(FUN, as.list(c(x[reg_inp], special)))
       } else if (length(reg_inp) == 1) {
         # If target function expects a single vector
-        ans <- as.numeric(do.call(FUN, as.list(c(list(x), special))))
+        ans <- do.call(FUN, as.list(c(list(x), special)))
       } else {
         # If targets are fixed
         ans <- FUN()


### PR DESCRIPTION
When user created their own target function and used names, define_target_function was removing the names from the output. This could lead to them not being ordered properly if user was defining them out of order with the expectation that the names would be used to manage the order.